### PR TITLE
Add Feedback Filtering for Admins

### DIFF
--- a/flightmate/src/main/java/com/flightmate/beans/Feedback.java
+++ b/flightmate/src/main/java/com/flightmate/beans/Feedback.java
@@ -6,13 +6,16 @@ public class Feedback {
 	private int feedbackId;
 	private User user;
 	private String feedbackType, feedbackComment;
+	private boolean hasRead;
+	
 	private LocalDate feedbackDate;
 		
-	public Feedback(int feedbackId, String feedbackType, String feedbackComment, LocalDate feedbackDate,  User user) {
+	public Feedback(int feedbackId, String feedbackType, String feedbackComment, LocalDate feedbackDate, boolean hasRead,  User user) {
 		this.feedbackId = feedbackId;
 		this.feedbackType = feedbackType;
 		this.feedbackComment = feedbackComment;
 		this.feedbackDate = feedbackDate;
+		this.hasRead = hasRead;
 		this.user = user;
 	}
 
@@ -27,7 +30,7 @@ public class Feedback {
 	public User getUser() {
 		return user;
 	}
-	public void setUserId(User user) {
+	public void setUser(User user) {
 		this.user = user;
 	}
 	public String getFeedbackType() {
@@ -42,6 +45,15 @@ public class Feedback {
 	public void setFeedbackComment(String feedbackComment) {
 		this.feedbackComment = feedbackComment;
 	}
+	
+	public boolean hasRead() {
+		return hasRead;
+	}
+
+	public void setHasRead(boolean hasRead) {
+		this.hasRead = hasRead;
+	}
+	
 	public LocalDate getFeedbackDate() {
 		return feedbackDate;
 	}

--- a/flightmate/src/main/java/com/flightmate/dao/ApplicationDao.java
+++ b/flightmate/src/main/java/com/flightmate/dao/ApplicationDao.java
@@ -224,6 +224,7 @@ public class ApplicationDao {
                         + "feedback_type VARCHAR(50) NOT NULL, "
                         + "feedback_date DATE NOT NULL DEFAULT (CURDATE()), "
                         + "feedback_comment TEXT NOT NULL, "
+                        + "has_read BOOLEAN DEFAULT FALSE, "
                         + "user_id INT NOT NULL, "
                         + "FOREIGN KEY (user_id) REFERENCES " + USERS_TABLE + "(user_id));";
                 stmt.executeUpdate(sql);

--- a/flightmate/src/main/java/com/flightmate/dao/FeedbackDao.java
+++ b/flightmate/src/main/java/com/flightmate/dao/FeedbackDao.java
@@ -90,7 +90,7 @@ public class FeedbackDao {
 	
 	public List<Feedback> getAllFeedback() {
 		List<Feedback> feedbackList = new ArrayList<>();
-		String sql = "SELECT * FROM "+ApplicationDao.FEEDBACK_TABLE+" INNER JOIN "+ ApplicationDao.USERS_TABLE +" ON "+ApplicationDao.FEEDBACK_TABLE+"."+UserDao.USER_ID+" = "+ApplicationDao.USERS_TABLE+"."+UserDao.USER_ID+" ORDER BY "+ApplicationDao.FEEDBACK_TABLE+"."+FEEDBACK_DATE+" DESC;";
+		String sql = "SELECT * FROM "+ApplicationDao.FEEDBACK_TABLE+" INNER JOIN "+ ApplicationDao.USERS_TABLE +" ON "+ApplicationDao.FEEDBACK_TABLE+"."+UserDao.USER_ID+" = "+ApplicationDao.USERS_TABLE+"."+UserDao.USER_ID+" ORDER BY "+ApplicationDao.FEEDBACK_TABLE+"."+FEEDBACK_DATE+" DESC, "+ApplicationDao.FEEDBACK_TABLE+"."+FEEDBACK_HAS_READ+" ASC;";
 		try (
 				Connection conn = DBConnection.getDBInstance();
 				PreparedStatement stmt = conn.prepareStatement(sql);

--- a/flightmate/src/main/java/com/flightmate/dao/FeedbackDao.java
+++ b/flightmate/src/main/java/com/flightmate/dao/FeedbackDao.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +20,7 @@ public class FeedbackDao {
 	private final String FEEDBACK_TYPE = "feedback_type";
 	private final String FEEDBACK_DATE = "feedback_date";
 	private final String FEEDBACK_COMMENT = "feedback_comment";
+	private final String FEEDBACK_HAS_READ = "has_read";
 	
 	private FeedbackDao() {};
 	
@@ -50,9 +52,45 @@ public class FeedbackDao {
 		}
 	}
 	
+	public Feedback getFeedbackById(int feedbackId) {
+		Feedback feedback = null;
+		String sql = "SELECT * FROM "+ApplicationDao.FEEDBACK_TABLE+" INNER JOIN "+ ApplicationDao.USERS_TABLE +" ON "+ApplicationDao.FEEDBACK_TABLE+"."+UserDao.USER_ID+" = "+ApplicationDao.USERS_TABLE+"."+UserDao.USER_ID+" WHERE "+FEEDBACK_ID+" = ?;";
+		try (
+				Connection conn = DBConnection.getDBInstance();
+				PreparedStatement stmt = conn.prepareStatement(sql);
+			) {
+				stmt.setInt(1, feedbackId);
+				ResultSet rs = stmt.executeQuery();
+				
+				if (rs != null && rs.next()) {
+					feedback = new FeedbackBuilder()
+							.setFeedbackId(rs.getInt(FEEDBACK_ID))
+							.setFeedbackType(rs.getString(FEEDBACK_TYPE))
+							.setFeedbackComment(rs.getString(FEEDBACK_COMMENT))
+							.setHasRead(rs.getBoolean(FEEDBACK_HAS_READ))
+							.setUser(new UserBuilder()
+									.setUserId(rs.getInt(UserDao.USER_ID))
+									.setFirstName(rs.getString(UserDao.FIRST_NAME))
+									.setLastName(rs.getString(UserDao.LAST_NAME))
+									.setEmail(rs.getString(UserDao.EMAIL_ADDRESS))
+									.setRoleId(rs.getInt(UserDao.ROLE_ID))
+									.create())
+							.setFeedbackDate(rs.getDate(FEEDBACK_DATE).toLocalDate())
+							.create();
+				}
+				
+			} catch (SQLException e) {
+				DBUtil.processException(e);
+			} catch (ClassNotFoundException e) {
+				e.printStackTrace();
+			}
+		
+		return feedback;
+	}
+	
 	public List<Feedback> getAllFeedback() {
 		List<Feedback> feedbackList = new ArrayList<>();
-		String sql = "SELECT * FROM "+ApplicationDao.FEEDBACK_TABLE+" INNER JOIN "+ ApplicationDao.USERS_TABLE +" ON "+ApplicationDao.FEEDBACK_TABLE+"."+UserDao.USER_ID+" = "+ApplicationDao.USERS_TABLE+"."+UserDao.USER_ID+";";
+		String sql = "SELECT * FROM "+ApplicationDao.FEEDBACK_TABLE+" INNER JOIN "+ ApplicationDao.USERS_TABLE +" ON "+ApplicationDao.FEEDBACK_TABLE+"."+UserDao.USER_ID+" = "+ApplicationDao.USERS_TABLE+"."+UserDao.USER_ID+" ORDER BY "+ApplicationDao.FEEDBACK_TABLE+"."+FEEDBACK_DATE+" DESC;";
 		try (
 				Connection conn = DBConnection.getDBInstance();
 				PreparedStatement stmt = conn.prepareStatement(sql);
@@ -63,6 +101,7 @@ public class FeedbackDao {
 						.setFeedbackId(rs.getInt(FEEDBACK_ID))
 						.setFeedbackType(rs.getString(FEEDBACK_TYPE))
 						.setFeedbackComment(rs.getString(FEEDBACK_COMMENT))
+						.setHasRead(rs.getBoolean(FEEDBACK_HAS_READ))
 						.setUser(new UserBuilder()
 								.setUserId(rs.getInt(UserDao.USER_ID))
 								.setFirstName(rs.getString(UserDao.FIRST_NAME))
@@ -81,5 +120,26 @@ public class FeedbackDao {
 		}
 		
 		return feedbackList;
+	}
+	
+	public boolean setFeedbackReadStatusById(boolean readStatus, int feedbackId) {
+		boolean updated = false;
+		String sql = "UPDATE "+ApplicationDao.FEEDBACK_TABLE+" SET "+FEEDBACK_HAS_READ+" = ? WHERE "+FEEDBACK_ID+" = ?;";
+		try (
+				Connection conn = DBConnection.getDBInstance();
+				PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+			) {
+			stmt.setBoolean(1, readStatus);
+			stmt.setInt(2, feedbackId);
+			
+			updated = stmt.executeUpdate() > 0;
+						
+		} catch (SQLException e) {
+			DBUtil.processException(e);
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+		}
+		
+		return updated;
 	}
 }

--- a/flightmate/src/main/java/com/flightmate/libs/builders/FeedbackBuilder.java
+++ b/flightmate/src/main/java/com/flightmate/libs/builders/FeedbackBuilder.java
@@ -9,6 +9,7 @@ public class FeedbackBuilder {
 	private int feedbackId;
 	private User user;
 	private String feedbackType, feedbackComment;
+	private boolean hasRead;
 	private LocalDate feedbackDate;
 	
 	public FeedbackBuilder setFeedbackId(int feedbackId) {
@@ -26,6 +27,11 @@ public class FeedbackBuilder {
 		return this;
 	}
 	
+	public FeedbackBuilder setHasRead(boolean hasRead) {
+		this.hasRead = hasRead;
+		return this;
+	}
+	
 	public FeedbackBuilder setFeedbackComment(String feedbackComment) {
 		this.feedbackComment = feedbackComment;
 		return this;
@@ -37,6 +43,6 @@ public class FeedbackBuilder {
 	}
 	
 	public Feedback create() {
-		return new Feedback(feedbackId, feedbackType, feedbackComment, feedbackDate, user);
+		return new Feedback(feedbackId, feedbackType, feedbackComment, feedbackDate, hasRead, user);
 	}
 }

--- a/flightmate/src/main/java/com/flightmate/servlets/feedback/FeedbackReadServlet.java
+++ b/flightmate/src/main/java/com/flightmate/servlets/feedback/FeedbackReadServlet.java
@@ -1,0 +1,47 @@
+package com.flightmate.servlets.feedback;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.flightmate.beans.Feedback;
+import com.flightmate.beans.User;
+import com.flightmate.dao.FeedbackDao;
+import com.flightmate.libs.Role;
+import com.flightmate.libs.services.SessionService;
+
+@WebServlet("/feedback-read")
+public class FeedbackReadServlet extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		User user = SessionService.srv.getSessionUser(req);
+		
+		if (user == null) {
+			resp.sendRedirect("./login");
+		}
+		
+		if (!user.getRole().equals(Role.ADMINISTRATOR)) {
+			resp.sendRedirect("./dashboard");
+		}
+		
+		int feedbackId = Integer.parseInt(req.getParameter("id"));
+		
+		Feedback feedback = FeedbackDao.getDao().getFeedbackById(feedbackId);
+		
+		if (feedback == null) {
+			req.setAttribute("message", "Could not find feedback.");
+		}
+		
+		boolean feedbackReadStatus = feedback.hasRead();
+		
+		FeedbackDao.getDao().setFeedbackReadStatusById(!feedbackReadStatus, feedbackId);
+		
+		resp.sendRedirect("./user-management");
+	}
+}

--- a/flightmate/src/main/java/com/flightmate/servlets/feedback/SubmitFeedbackServlet.java
+++ b/flightmate/src/main/java/com/flightmate/servlets/feedback/SubmitFeedbackServlet.java
@@ -1,4 +1,4 @@
-package com.flightmate.servlets;
+package com.flightmate.servlets.feedback;
 
 import java.io.IOException;
 
@@ -14,7 +14,7 @@ import com.flightmate.libs.Route;
 import com.flightmate.libs.services.SessionService;
 
 @WebServlet("/submitFeedback")
-public class FeedbackServlet extends HttpServlet {
+public class SubmitFeedbackServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 
 	@Override

--- a/flightmate/src/main/java/com/flightmate/servlets/pages/UserManagementServlet.java
+++ b/flightmate/src/main/java/com/flightmate/servlets/pages/UserManagementServlet.java
@@ -2,6 +2,7 @@ package com.flightmate.servlets.pages;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -55,9 +56,19 @@ public class UserManagementServlet extends HttpServlet {
         
         List<User> userList = UserDao.getDao().getAllUsers();
         req.setAttribute("users", userList);
-    
+        
+        
+        // Generate feedback list based on filter param
         List<Feedback> feedbackList = FeedbackDao.getDao().getAllFeedback();
-        req.setAttribute("feedback", feedbackList);
+        String filterType = req.getParameter("filterType") != null ? req.getParameter("filterType") : "all";
+        List<Feedback> filteredFeedback = feedbackList;
+        if (filterType.equals("read")) {
+        	filteredFeedback = feedbackList.stream().filter(Feedback::hasRead).collect(Collectors.toList());
+        } else if (filterType.equals("unread")) {
+        	filteredFeedback = feedbackList.stream().filter(feedback -> !feedback.hasRead()).collect(Collectors.toList());
+        }
+        
+        req.setAttribute("feedback", filteredFeedback);
         
         req.getRequestDispatcher(Route.USER_MANAGEMENT).forward(req, resp);
 	}

--- a/flightmate/src/main/webapp/css/dashboard.css
+++ b/flightmate/src/main/webapp/css/dashboard.css
@@ -76,37 +76,6 @@ main {
 }
 
 /* ****************** */
-/* Table              */
-/* ****************** */
-
-.temptable, .temptable th, .temptable td {
-    margin: 0;
-}
-
-.temptable th, .temptable td {
-    border: 1px solid black;
-    text-align: left;         
-    padding: 4px;     
-}
-
-.temptable, .temptable th, .temptable td {
-    margin: 0;
-}
-
-.temptable th {
-    background-color: #007bff; 
-    color: white; 
-    border: 1px solid #007bff;
-    text-align: left;
-    padding: 4px;
-}
-
-.temptable td {
-    padding: 4px;
-    vertical-align: top;
-}
-
-/* ****************** */
 /* Dashboard Table    */
 /* ****************** */
 
@@ -147,6 +116,14 @@ main {
 
 .dashboard-table tbody tr:nth-child(odd) {
     background-color: #fff;
+}
+
+.isRead {
+	background-color: #d4d4d4 !important;
+}
+
+.isUnread {
+	font-weight: var(--fw-semibold);
 }
 
 .dashboard-table td {

--- a/flightmate/src/main/webapp/user-management.jsp
+++ b/flightmate/src/main/webapp/user-management.jsp
@@ -11,7 +11,7 @@
     <jsp:include page='./components/header.jsp' />
     <main>
 		<section class="container mt-2">
-			<h2 class="section-title center">User Management</h2>
+			<h2 class="section-title">User Management</h2>
             <table class="dashboard-table w-full border-2 rounded mt-2">
                 <thead>
                     <tr>
@@ -44,27 +44,38 @@
         	</table>
 		</section>
 		<section class="container mt-2">
-			<h2 class="section-title center">User Feedback</h2>
+			<header>
+				<h2 class="section-title center">User Feedback</h2>
+				<form method="get" action="user-management" class="filter-form mb-2">
+			        <label for="filterType" class="mr-2">Filter by:</label>
+			        <select name="filterType" id="filterType" class="form-single-select mr-2">
+			            <option value="all" ${param.filterType == 'all' ? 'selected' : ''}>All</option>
+			            <option value="read" ${param.filterType == 'read' ? 'selected' : ''}>Read</option>
+			            <option value="unread" ${param.filterType == 'unread' ? 'selected' : ''}>Unread</option>
+			        </select>
+			        <button type="submit" class="btn">Apply</button>
+			    </form>
+		    </header>
             <table class="dashboard-table w-full border-2 rounded mt-2">
                 <thead>
                     <tr>
-                        <th>Feedback ID</th>
+                        <th>Date</th>
                         <th>Name</th>
                         <th>Email</th>
                         <th>Feedback Type</th>
-                        <th>Date</th>
                         <th>Comment</th>
+                        <th>Read Status</th>
                     </tr>
                 </thead>
                 <tbody>
 	                <c:forEach var="feedbackItem" items="${feedback}">
-		                <tr>
-		                    <td>${feedbackItem.getFeedbackId()}</td>
+		                <tr class="${feedbackItem.hasRead() ? 'isRead' : 'isUnread' }">
+		                    <td>${feedbackItem.getFeedbackDate()}</td>
 		                    <td>${feedbackItem.getUser().getFirstName()} ${feedbackItem.getUser().getLastName()}</td>
 		                    <td>${feedbackItem.getUser().getEmail()}</td>
 		                    <td>${feedbackItem.getFeedbackType()}</td>
-		                    <td>${feedbackItem.getFeedbackDate()}</td>
 		                    <td>${feedbackItem.getFeedbackComment()}</td>
+		                    <td><a href="feedback-read?id=${feedbackItem.getFeedbackId()}" class="btn">${feedbackItem.hasRead() ? "Mark as Unread" : "Mark as Read"}</a></td>
 		                </tr>
 	                </c:forEach>
             	</tbody>


### PR DESCRIPTION
This change introduces the possibility for administrators to filter feedback based on read status.
- When a piece of feedback is created by a pilot, it is marked as "unread" by default.
- An admin can toggle the feedback as "read" or "unread". This will update it in the database.
- Feedback is sorted by date, then by read status.
- Over the "feedback list" in the user management page, the admin can filter the feedback by "All", "Unread" and "Read" status.